### PR TITLE
rename Fast Pipe to Pipe First

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,6 @@ node_modules
 _build
 _release
 _esy
-fast_pipe.install
+pipe_first.install
 .DS_Store
 *.install

--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
-# Fast pipe ppx [![Build Status](https://travis-ci.org/IwanKaramazow/FastPipe.svg?branch=master)](https://travis-ci.org/IwanKaramazow/FastPipe)
+# Pipe First ppx [![Build Status](https://travis-ci.org/IwanKaramazow/PipeFirst.svg?branch=master)](https://travis-ci.org/IwanKaramazow/PipeFirst)
 
 Pipe first as a syntax transform. Transforms expressions containing the `|.` (Ocaml) or `->` (Reason) operator.
 Pipes the left side as first argument of the right side.
 
-*Reason*
+_Reason_
+
 ```reason
 /* validateAge(getAge(parseData(person))) */
 person
@@ -18,7 +19,8 @@ name->preprocess->Some;
 a->f(~b, ~c)
 ```
 
-*Ocaml*
+_Ocaml_
+
 ```ocaml
 (* validateAge (getAge (parseData person)) *)
 person
@@ -34,14 +36,17 @@ a |. f ~b ~c
 ```
 
 ## Usage with Dune
+
 `dune` file
+
 ```
 (executable
   (name hello_world)
-  (preprocess  (pps ppx_fast_pipe))
+  (preprocess  (pps ppx_pipe_first))
 ```
 
 Reason: implementation of the `hello_world.re` file
+
 ```reason
 let () =
   1000
@@ -50,6 +55,7 @@ let () =
 ```
 
 Ocaml: implementation of the `hello_world.ml` file
+
 ```ocaml
 let () =
   1000

--- a/dune-project
+++ b/dune-project
@@ -1,2 +1,2 @@
 (lang dune 1.2)
- (name fast_pipe_ppx)
+ (name pipe_first_ppx)

--- a/package.json
+++ b/package.json
@@ -1,11 +1,13 @@
 {
-  "name": "ppx_fast_pipe",
+  "name": "ppx_pipe_first",
   "version": "0.0.1",
-  "description": "Fast pipe: pipe first as a syntax transform",
+  "description": "Pipe First: pipe first as a syntax transform",
   "esy": {
-    "build": "refmterr dune build -p ppx_fast_pipe"
+    "build": "refmterr dune build -p ppx_pipe_first"
   },
-  "scripts": { "test": "esy dune runtest" },
+  "scripts": {
+    "test": "esy dune runtest"
+  },
   "dependencies": {
     "@esy-ocaml/reason": "*",
     "@opam/dune": "*",
@@ -13,5 +15,7 @@
     "ocaml": "^4.4.0",
     "refmterr": "*"
   },
-  "devDependencies": { "@opam/merlin": "*" }
+  "devDependencies": {
+    "@opam/merlin": "*"
+  }
 }

--- a/ppx/dune
+++ b/ppx/dune
@@ -1,6 +1,6 @@
 (library
- (name ppx_fast_pipe)
- (public_name ppx_fast_pipe)
+ (name ppx_pipe_first)
+ (public_name ppx_pipe_first)
  (synopsis "Pipe first syntax transform")
  (kind ppx_rewriter)
  (libraries reason ocaml-migrate-parsetree))

--- a/ppx/ppx_fast_pipe.re
+++ b/ppx/ppx_fast_pipe.re
@@ -82,6 +82,6 @@ let mapper = {
 
 let () =
   Driver.register(
-    ~name="ppx_fast_pipe", ~args=[], Versions.ocaml_406, (_config, _cookies) =>
+    ~name="ppx_pipe_first", ~args=[], Versions.ocaml_406, (_config, _cookies) =>
     mapper
   );

--- a/ppx_pipe_first.opam
+++ b/ppx_pipe_first.opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
 version: "0.0.1"
-synopsis: "Fast pipe, pipe first as a syntax transform"
+synopsis: "Pipe First as a syntax transform"
 description: """
 Pipe first as a syntax transform.
 Provides a ppx to transform expressions containing the |. (Ocaml) or -> (Reason)
@@ -37,9 +37,9 @@ a |. f ~b ~c
 maintainer: "Iwan Karamazow <m.falka@icloud.com>"
 authors: "Iwan Karamazow m.falka@icloud.com"
 license: "MIT"
-homepage: "https://github.com/IwanKaramazow/FastPipe"
-bug-reports: "https://github.com/IwanKaramazow/FastPipe"
-dev-repo: "git://github.com/IwanKaramazow/FastPipe.git"
+homepage: "https://github.com/IwanKaramazow/PipeFirst"
+bug-reports: "https://github.com/IwanKaramazow/PipeFirst"
+dev-repo: "git://github.com/IwanKaramazow/PipeFirst.git"
 depends: [ 
   "ocaml" {>= "4.02" & < "4.08"}
   "reason" {>= "3.3.7"}

--- a/test/TestFastPipe.re
+++ b/test/TestFastPipe.re
@@ -111,4 +111,4 @@ let ten2 = 5->(5->adder);
 
 assert(10 === ten1 && 10 === ten2);
 
-let () = print_endline("Fast pipe tests passed!");
+let () = print_endline("Pipe First tests passed!");

--- a/test/dune
+++ b/test/dune
@@ -1,3 +1,3 @@
 (test
-  (name TestFastPipe)
-  (preprocess (pps ppx_fast_pipe)))
+  (name TestPipeFirst)
+  (preprocess (pps ppx_pipe_first)))


### PR DESCRIPTION
@IwanKaramazow If I'm not mistaken you can rename the repo in the settings and Github will maintain a proper redirect until you create another repository `FastPipe`